### PR TITLE
Support load DB according to the files found from the input path

### DIFF
--- a/bdap-engine/src/main/java/etl/cmd/LoadDataCmd.java
+++ b/bdap-engine/src/main/java/etl/cmd/LoadDataCmd.java
@@ -2,19 +2,32 @@ package etl.cmd;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+
 import javax.script.CompiledScript;
 
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.lib.output.MultipleOutputs;
 //log4j2
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import etl.engine.ETLCmd;
 import etl.util.DBType;
 import etl.util.DBUtil;
 import etl.util.ScriptEngineUtil;
+import scala.Tuple2;
 
 public class LoadDataCmd extends SchemaETLCmd{
 	private static final long serialVersionUID = 1L;
+	private static final String NO_TABLE_CONFIGURED = "<no-table-configured>";
+	private static final String[] EMPTY_STRING_ARRAY = new String[0];
 	public static final Logger logger = LogManager.getLogger(LoadDataCmd.class);
 	//cfgkey
 	public static final String cfgkey_webhdfs="hdfs.webhdfs.root";
@@ -76,25 +89,14 @@ public class LoadDataCmd extends SchemaETLCmd{
 		copysqls = new ArrayList<String>();
 	}
 	
-	@Override
-	public List<String> sgProcess() {
-		if (this.getFs()==null) init();
-		List<String> logInfo = new ArrayList<String>();
+	private List<String> prepareTableCopySQLs(String tableName, String[] files) {
+		List<String> newCopysqls = new ArrayList<String>();
 		try{
 			String sql = null;
-			if (logicSchema!=null && (csLoadSql==null||loadSql.contains(VAR_TABLE_NAME))){	
-				List<String> tryTables = new ArrayList<String>();
-				if (tableNames==null || tableNames.length==0){//default sql, match all the files against the tables
-					tryTables.addAll(logicSchema.getAttrNameMap().keySet());
-				}else{
-					tryTables.addAll(Arrays.asList(tableNames));
-				}
-			
-				for (String tableName:tryTables){
-					String csvFileName = null;
-					this.getSystemVariables().put(VAR_TABLE_NAME, tableName);
-					csvFileName = ScriptEngineUtil.eval(this.csCsvFile, this.getSystemVariables());
-					//
+			if (logicSchema!=null && (csLoadSql==null||loadSql.contains(VAR_TABLE_NAME))){
+				this.getSystemVariables().put(VAR_TABLE_NAME, tableName);
+				
+				for (String csvFileName: files) {
 					this.getSystemVariables().put(VAR_CSV_FILE, csvFileName);
 					
 					if (csLoadSql!=null){
@@ -103,15 +105,55 @@ public class LoadDataCmd extends SchemaETLCmd{
 						sql = DBUtil.genCopyHdfsSql(null, logicSchema.getAttrNames(tableName), tableName, 
 								dbPrefix, this.webhdfsRoot, csvFileName, this.userName, this.getDbtype());
 					}
-					copysqls.add(sql);
+					newCopysqls.add(sql);
+
+					logger.info(String.format("sql:%s", sql));
+				}
+			}else if (csLoadSql!=null){//just evaluate the loadSql
+				for (String csvFileName: files) {
+					this.getSystemVariables().put(VAR_CSV_FILE, csvFileName);
+					sql = ScriptEngineUtil.eval(csLoadSql, this.getSystemVariables());
+					newCopysqls.add(sql);
+					
+					logger.info(String.format("sql:%s", sql));
+				}
+			}
+		}catch(Exception e){
+			logger.error("", e);
+		}
+		return newCopysqls;
+	}
+	
+	@Override
+	public List<String> sgProcess() {
+		if (this.getFs()==null) init();
+		List<String> logInfo = new ArrayList<String>();
+		try{
+			String csvFileName = null;
+			String[] files;
+			if (logicSchema!=null && (csLoadSql==null||loadSql.contains(VAR_TABLE_NAME))){
+				List<String> tryTables = new ArrayList<String>();
+				if (tableNames==null || tableNames.length==0){//default sql, match all the files against the tables
+					tryTables.addAll(logicSchema.getAttrNameMap().keySet());
+				}else{
+					tryTables.addAll(Arrays.asList(tableNames));
+				}
+			
+				for (String tableName:tryTables){
+					this.getSystemVariables().put(VAR_TABLE_NAME, tableName);
+					csvFileName = ScriptEngineUtil.eval(this.csCsvFile, this.getSystemVariables());
+					files = new String[] {csvFileName};
+					copysqls.addAll(
+						prepareTableCopySQLs(tableName, files)
+					);
 				}
 			}else{//just evaluate the loadSql
-				String csvFileName = ScriptEngineUtil.eval(this.csCsvFile, this.getSystemVariables());
-				this.getSystemVariables().put(VAR_CSV_FILE, csvFileName);
-				sql = ScriptEngineUtil.eval(csLoadSql, this.getSystemVariables());
-				copysqls.add(sql);
+				csvFileName = ScriptEngineUtil.eval(this.csCsvFile, this.getSystemVariables());
+				files = new String[] {csvFileName};
+				copysqls.addAll(
+					prepareTableCopySQLs(null, files)
+				);
 			}
-			logger.info(String.format("sql:%s", sql));
 		}catch(Exception e){
 			logger.error("", e);
 		}
@@ -122,6 +164,58 @@ public class LoadDataCmd extends SchemaETLCmd{
 		}
 		
 		return  logInfo;
+	}
+	
+	public Map<String, Object> mapProcess(long offset, String row,
+			Mapper<LongWritable, Text, Text, Text>.Context context) throws Exception {
+		Map<String, Object> ret = new HashMap<String, Object>();
+		List<Tuple2<String, String>> vl = new ArrayList<Tuple2<String, String>>();
+		if (row.startsWith("hdfs://")) {
+			/* Locate from the root path */
+			row = row.substring(7);
+			row = row.substring(row.indexOf("/"));
+		}
+		if (logicSchema!=null && (csLoadSql==null||loadSql.contains(VAR_TABLE_NAME))){
+			/* File to table mapping */
+			String tableName = this.getTableName(row);
+			vl.add(new Tuple2<String, String>(tableName, row));
+		}else{
+			vl.add(new Tuple2<String, String>(NO_TABLE_CONFIGURED, row));
+		}
+		ret.put(RESULT_KEY_OUTPUT_TUPLE2, vl);
+		return ret;
+	}
+	
+	public List<String[]> reduceProcess(Text key, Iterable<Text> values,
+			Reducer<Text, Text, Text, Text>.Context context, MultipleOutputs<Text, Text> mos) throws Exception {
+		List<String[]> ret = new ArrayList<String[]>();
+		if (NO_TABLE_CONFIGURED.equals(key.toString()))
+			copysqls.addAll(
+				prepareTableCopySQLs(null, toFiles(values))
+			);
+		else
+			copysqls.addAll(
+				prepareTableCopySQLs(key.toString(), toFiles(values))
+			);
+		if (super.getDbtype()!=DBType.NONE){
+			int rowsAdded = DBUtil.executeSqls(copysqls, super.getPc());
+			ret.add(new String[]{Integer.toString(rowsAdded), null, ETLCmd.SINGLE_TABLE});
+		}
+		return ret;
+	}
+
+	private String[] toFiles(Iterable<Text> values) {
+		List<String> files = new ArrayList<String>();
+		Iterator<Text> it = values.iterator();
+		while (it.hasNext()) {
+			String v = it.next().toString();
+			files.add(v);
+		}
+		return files.toArray(EMPTY_STRING_ARRAY);
+	}
+
+	public boolean hasReduce() {
+		return true;
 	}
 
 	public List<String> getCopysqls() {

--- a/bdap-engine/src/test/resources/loadcsv/loadcsvmr.properties
+++ b/bdap-engine/src/test/resources/loadcsv/loadcsvmr.properties
@@ -1,0 +1,6 @@
+table.names=MyCore_,MyCore1_
+csv.file='/test/loadcsv/input/'+ tableName + '.csv'
+load.sql= var dbutilclass = Java.type(\"etl.util.DBUtil\"); dbutilclass.genCopyHdfsSql(null\, logicSchema.getAttrNames(tableName)\, tableName\, dbPrefix\, rootWebHdfs\, csvFileName\, userName\, dbType)
+schema.file=/test/loadcsv/schema/multipleTableSchemas.txt
+db.prefix=sgsiwf
+file.table.map=filename.substring(0\,filename.indexOf('.csv'))


### PR DESCRIPTION
Configuration is the same, but inherit the existing file table mapping config
e.g.
  file.table.map=filename.substring(0\,filename.indexOf('.csv'))

The process logic is: first in mapping process, group all files by the tablename, if no table name specified, group all files to the key <no-table-configured>
In reduce process, load all files table by table.

Total loaded rows will be saved to the output file (part-r-????)of reduce process.

The original java single process is still supported.