### PR TITLE
Parquet file timestamp timezone

### DIFF
--- a/bdap-engine/src/main/java/etl/cmd/test/TestETLCmd.java
+++ b/bdap-engine/src/main/java/etl/cmd/test/TestETLCmd.java
@@ -13,6 +13,7 @@ import java.util.Map;
 //log4j2
 import etl.util.DateUtil;
 import etl.util.NanoTimeUtils;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.parquet.column.page.PageReadStore;
@@ -294,7 +295,7 @@ public abstract class TestETLCmd implements Serializable{
 						} else if (PrimitiveTypeName.INT96.equals(c.getPrimitiveTypeName())) {
 							if (c.getOriginalType() == null) {
 								NanoTime nt = NanoTime.fromBinary(g.getInt96(fieldIndex, 0));
-								buffer.append(FieldType.sdatetimeFormat.format(new Date(NanoTimeUtils.getTimestamp(nt, false))));
+								buffer.append(FieldType.sdatetimeFormat.format(new Date(NanoTimeUtils.getTimestamp(nt, getConf().getBoolean(HiveConf.ConfVars.HIVE_PARQUET_TIMESTAMP_SKIP_CONVERSION.varname, true)))));
 							}
 						} else if (PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY.equals(c.getPrimitiveTypeName())) {
 							b = g.getBinary(fieldIndex, 0);

--- a/bdap-engine/src/main/java/etl/util/NanoTimeUtils.java
+++ b/bdap-engine/src/main/java/etl/util/NanoTimeUtils.java
@@ -306,7 +306,7 @@ public class NanoTimeUtils {
     public static NanoTime getNanoTime(long timestamp, boolean skipConversion) {
         Timestamp ts = new Timestamp(timestamp);
         Calendar calendar = getCalendar(skipConversion);
-        calendar.setTime(ts);
+        calendar.setTimeInMillis(timestamp);
         int year = calendar.get(Calendar.YEAR);
         if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
             year = 1 - year;

--- a/bdap-engine/src/test/java/etl/engine/test/TestNanoTimeUtils.java
+++ b/bdap-engine/src/test/java/etl/engine/test/TestNanoTimeUtils.java
@@ -1,0 +1,27 @@
+package etl.engine.test;
+
+import etl.util.FieldType;
+import etl.util.GroupFun;
+import etl.util.NanoTimeUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.parquet.example.data.simple.NanoTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Date;
+
+public class TestNanoTimeUtils {
+    public static final Logger logger = LogManager.getLogger(TestNanoTimeUtils.class);
+
+    @Test
+    public void test() throws Exception {
+        String datetime = GroupFun.dtStandardize("2016-07-24T00:00:00-05:00", "yyyy-MM-dd'T'HH:mm:ssXXX");
+        Date d = FieldType.sdatetimeFormat.parse(datetime);
+        NanoTime nt = NanoTimeUtils.getNanoTime(d.getTime(), false);
+        logger.info(d);
+        long t = NanoTimeUtils.getTimestamp(nt, false);
+        logger.info(new Date(t));
+        Assert.assertEquals(d.getTime(), t);
+    }
+}


### PR DESCRIPTION
When save as parquet file, the timestamp column having the following configuration to control compatibility with impala or hive
hive.parquet.timestamp.skip.conversion = true (default value, impala)
hive.parquet.timestamp.skip.conversion = false (hive)